### PR TITLE
Fix software xy limits

### DIFF
--- a/xy_tracking.py
+++ b/xy_tracking.py
@@ -911,7 +911,7 @@ class Backend(QtCore.QObject):
                 new_y *= correct_factor
             dy = -new_y / 1000  # conversion to µm
 
-        if dx > security_thr or dy > security_thr:
+        if abs(dx) > security_thr or abs(dy) > security_thr:
             print(datetime.now(), f'[xy_tracking] Correction movement larger than {int(security_thr*1000)} nm, active correction turned OFF')
             self.toggle_feedback(False)
         else:

--- a/xy_tracking.py
+++ b/xy_tracking.py
@@ -895,35 +895,26 @@ class Backend(QtCore.QObject):
         threshold = 5
         far_threshold = 12
         correct_factor = 0.6
-        security_thr = 0.35 # in µm
-        
-        if np.abs(self.x) > threshold:
-            
-            if dx < far_threshold:
-                
-                dx = correct_factor * dx
-            
-            dx = - (self.x)/1000 # conversion to µm
+        security_thr = 0.35  # in µm
 
-#                print('dx', dx)
-            
-        if np.abs(self.y) > threshold:
-            
-            if dy < far_threshold:
-                
-                dy = correct_factor * dy
-            
-            dy = - (self.y)/1000 # conversion to µm
-            
-#                print('dy', dy)
-    
+        abs_x = np.abs(self.x)
+        new_x = self.x
+        if abs_x > threshold:
+            if abs_x < far_threshold:
+                new_x *= correct_factor
+            dx = -new_x / 1000  # conversion to µm
+
+        abs_y = np.abs(self.y)
+        new_y = self.y
+        if abs_y > threshold:
+            if abs_y < far_threshold:
+                new_y *= correct_factor
+            dy = -new_y / 1000  # conversion to µm
+
         if dx > security_thr or dy > security_thr:
-            
             print(datetime.now(), '[xy_tracking] Correction movement larger than 200 nm, active correction turned OFF')
             self.toggle_feedback(False)
-            
         else:
-            
             # compensate for the mismatch between camera/piezo system of reference
             
             theta = np.radians(-3.7)   # 86.3 (or 3.7) is the angle between camera and piezo (measured)

--- a/xy_tracking.py
+++ b/xy_tracking.py
@@ -912,7 +912,7 @@ class Backend(QtCore.QObject):
             dy = -new_y / 1000  # conversion to µm
 
         if dx > security_thr or dy > security_thr:
-            print(datetime.now(), '[xy_tracking] Correction movement larger than 200 nm, active correction turned OFF')
+            print(datetime.now(), f'[xy_tracking] Correction movement larger than {int(security_thr*1000)} nm, active correction turned OFF')
             self.toggle_feedback(False)
         else:
             # compensate for the mismatch between camera/piezo system of reference

--- a/xyz_tracking.py
+++ b/xyz_tracking.py
@@ -1099,61 +1099,37 @@ class Backend(QtCore.QObject):
             dx = 0
             dy = 0
             dz = 0
-            # threshold = 3
-            # far_threshold = 12
-            # correct_factor = 0.6
-            
             threshold = 3
             z_threshold = 3
             far_threshold = 12
             correct_factor = 0.6
                         
             if np.abs(xmean) > threshold:
-                
                 dx = - (xmean)/1000 # conversion to µm
-                
-                if dx < far_threshold: #TODO: double check this conditions (do they work?)
-                    
+                if np.abs(dx) < far_threshold: #TODO: double check this conditions (do they work?)
                     dx = correct_factor * dx #TODO: double check this conditions (do they work?)
-    
-    #                print('dx', dx)
-                
+                    # print('dx', dx)
             if np.abs(ymean) > threshold:
-                            
                 dy = - (ymean)/1000 # conversion to µm
-                
-                if dy < far_threshold:
-                    
+                if np.abs(dy) < far_threshold:
                     dy = correct_factor * dy
-                
-    #                print('dy', dy)
+                    # print('dy', dy)
     
             if np.abs(self.z) > z_threshold:
-                            
                 dz = - (self.z)/1000 # conversion to µm
-                
-                if dz < far_threshold:
-                    
+                if np.abs(dz) < far_threshold:
                     dz = correct_factor * dz
-                
-    #                print('dy', dy)
-    
+                    # print('dz', dz)
         elif mode == 'PI':
-            
-            pass
-        
             dx = self.pi_x.update(xmean)
             dy = self.pi_y.update(ymean)
             dz = self.pi_z.update(self.z)
-        
         else:
-            
             print('Please choose a valid feedback mode')
             print('Feedback modes: ON/OFF, PI')
-    
-        if dx > security_thr or dy > security_thr or dz > 2 * security_thr:
-            
-            print(datetime.now(), '[xy_tracking] Correction movement larger than 200 nm, active correction turned OFF')
+
+        if abs(dx) > security_thr or abs(dy) > security_thr or abs(dz) > 2 * security_thr:
+            print(datetime.now(), f'[{__name__}] Correction movement larger than {int(security_thr*1000)} nm, active correction turned OFF')
             self.toggle_feedback(False)
             
         else:


### PR DESCRIPTION
The comparison to scale down the movement was made with the wrong variables (as `dx` and `dy` were always zero). this was fixed and the warning string printed to screen was modified so it informs what the program actually does.

WARNING: this PR changes the program behavior, as puts in effect a scaling down of the correction that is not currently applied